### PR TITLE
fix index out of bounds when header has fewer columns than data

### DIFF
--- a/csvwriter.go
+++ b/csvwriter.go
@@ -111,7 +111,7 @@ func (p *CsvWriter) WriteCsvLineRaw(val []string) {
 // HeaderUsage updates the header usage for a single row
 func (p *CsvWriter) HeaderUsage(val []string) {
 	for i, v := range val {
-		if len(v) > 0 {
+		if len(v) > 0 && i < len(p.headerUsage) {
 			p.headerUsage[i] = true
 		}
 	}


### PR DESCRIPTION
to fix https://github.com/public-transport/transitous/pull/1170, more precisely
```
Error: runtime error: index out of range [1] with length 1
Error: Could not postprocess fr-gtfs-transport-horaires-chemins-de-fer-corse-1: File is not a zip file
```